### PR TITLE
Add TUFFIN advertisement page, asset, and styles

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,6 +15,7 @@
         <div class="spacer"></div>
         <a class="nav-link" href="index.html">Home</a>
         <a class="nav-link active" href="about.html">About</a>
+        <a class="nav-link" href="ad.html">Ad</a>
         <button id="toggle-theme" class="btn small" aria-label="Toggle theme">Light/Dark</button>
       </nav>
     </header>

--- a/ad.html
+++ b/ad.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>My First Website</title>
+    <title>Tuffin Ad • My First Website</title>
     <link rel="stylesheet" href="style.css" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✨</text></svg>">
     <script defer src="script.js"></script>
@@ -13,35 +13,29 @@
       <nav class="container nav">
         <a class="brand" href="index.html">My First Website</a>
         <div class="spacer"></div>
-        <a class="nav-link active" href="index.html">Home</a>
+        <a class="nav-link" href="index.html">Home</a>
         <a class="nav-link" href="about.html">About</a>
-        <a class="nav-link" href="ad.html">Ad</a>
+        <a class="nav-link active" href="ad.html">Ad</a>
         <button id="toggle-theme" class="btn small" aria-label="Toggle theme">Light/Dark</button>
       </nav>
     </header>
 
-    <main class="container">
-      <section class="hero">
-        <h1>🎉 Hello from my first website!</h1>
-        <p>This is a basic site using HTML, CSS, and JavaScript. Edit files, save, and watch Live Server refresh.</p>
-      </section>
+    <main class="container ad-page">
+      <section class="ad-wrap" aria-label="Advertisement for Tuffin High Protein Muffins">
+        <h1 class="ad-title">NOW PUMPING: TUFFIN</h1>
+        <p class="ad-subtitle">HIGH PROTEIN MUFFINS • GYM FUEL • GET TUFFIN!</p>
 
-      <section class="grid">
-        <article class="card">
-          <h2>Click Counter</h2>
-          <p>Clicks: <span id="count">0</span></p>
-          <div class="row">
-            <button id="add" class="btn">Add one</button>
-            <button id="reset" class="btn outline">Reset</button>
-          </div>
-        </article>
+        <figure class="ad-image-frame">
+          <img
+            class="ad-image"
+            src="assets/tuffin-ad.svg"
+            alt="Tuffin High Protein Muffins retro gym advertisement"
+            loading="lazy"
+          />
+          <figcaption>When your bulk needs baked goods, go full TUFFIN mode.</figcaption>
+        </figure>
 
-        <article class="card">
-          <h2>Live Clock</h2>
-          <p id="clock" class="mono">--:--:--</p>
-        </article>
-        <p>This line was added on a feature branch as a PR test.</p>
-
+        <a class="btn ad-cta" href="#" aria-label="Mock call to action">Grab a 12-pack</a>
       </section>
     </main>
 

--- a/assets/tuffin-ad.svg
+++ b/assets/tuffin-ad.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="1600" viewBox="0 0 900 1600" role="img" aria-labelledby="title desc">
+  <title id="title">TUFFIN high protein muffins ad</title>
+  <desc id="desc">Retro style gym themed ad for Tuffin muffins.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1f2937"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+    <linearGradient id="titleFill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fde047"/>
+      <stop offset="100%" stop-color="#facc15"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="900" height="1600" fill="url(#bg)"/>
+  <rect x="30" y="30" width="840" height="1540" fill="none" stroke="#38bdf8" stroke-width="8"/>
+
+  <text x="450" y="220" text-anchor="middle" font-family="Impact, Arial Black, sans-serif" font-size="180" fill="url(#titleFill)" stroke="#ef4444" stroke-width="12" transform="skewX(-8)">TUFFIN</text>
+  <text x="450" y="320" text-anchor="middle" font-family="Arial Black, sans-serif" font-size="64" fill="#7dd3fc" stroke="#0f172a" stroke-width="4">HIGH PROTEIN MUFFINS</text>
+
+  <rect x="180" y="420" width="540" height="760" rx="40" fill="#0b1220" stroke="#f59e0b" stroke-width="8"/>
+  <circle cx="450" cy="620" r="110" fill="#f59e0b"/>
+  <rect x="350" y="740" width="200" height="320" rx="60" fill="#fb923c"/>
+  <rect x="300" y="790" width="90" height="260" rx="40" fill="#fdba74"/>
+  <rect x="510" y="790" width="90" height="260" rx="40" fill="#fdba74"/>
+  <text x="450" y="1140" text-anchor="middle" font-family="Arial, sans-serif" font-size="38" fill="#e2e8f0">(stylized ad art)</text>
+
+  <text x="80" y="1430" font-family="Impact, Arial Black, sans-serif" font-size="120" fill="#fde047" stroke="#0f172a" stroke-width="8">GET TUFFIN!</text>
+
+  <g transform="translate(620,1300)">
+    <ellipse cx="70" cy="120" rx="70" ry="30" fill="#7c2d12"/>
+    <path d="M20 120 Q70 20 120 120 Z" fill="#d97706"/>
+    <ellipse cx="230" cy="120" rx="70" ry="30" fill="#7c2d12"/>
+    <path d="M180 120 Q230 20 280 120 Z" fill="#b45309"/>
+  </g>
+</svg>

--- a/style.css
+++ b/style.css
@@ -115,3 +115,60 @@ body {
 }
 .repo-link { color: var(--accent); text-decoration: none; }
 .repo-link:hover { text-decoration: underline; }
+
+.ad-page {
+  padding: 28px 16px 32px;
+}
+
+.ad-wrap {
+  background: radial-gradient(circle at top, #1f2937 0%, #0b1020 70%);
+  border: 1px solid #334155;
+  border-radius: 18px;
+  padding: 22px;
+  box-shadow: 0 18px 35px rgba(0, 0, 0, 0.25);
+  color: #e5f7ff;
+  text-align: center;
+}
+
+.ad-title {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #fde047;
+  text-shadow: 0 2px 0 #ef4444, 0 0 10px rgba(59, 130, 246, 0.35);
+}
+
+.ad-subtitle {
+  margin: 8px auto 18px;
+  max-width: 50ch;
+  font-weight: 700;
+  color: #7dd3fc;
+}
+
+.ad-image-frame {
+  margin: 0 auto;
+  max-width: 360px;
+}
+
+.ad-image {
+  width: 100%;
+  border-radius: 12px;
+  border: 2px solid #facc15;
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.38);
+}
+
+.ad-image-frame figcaption {
+  margin-top: 10px;
+  color: #bfdbfe;
+  font-style: italic;
+}
+
+.ad-cta {
+  margin-top: 14px;
+  display: inline-block;
+  background: #facc15;
+  color: #111827;
+  border-color: #facc15;
+  font-weight: 700;
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated advertisement-style page that displays the supplied image as a promotional poster and fits visually with the rest of the site.
- Make the ad discoverable from the site header so users can navigate to the new page from `index.html` and `about.html`.

### Description
- Add a new page `ad.html` containing a poster-style ad layout (headline, subtitle, framed image, figcaption, and CTA button).
- Add a local image asset at `assets/tuffin-ad.svg` and wire it into the ad page image element (replacing an external image URL used during development).
- Update `index.html` and `about.html` to include an `Ad` navigation link so the new page is reachable from existing pages.
- Extend `style.css` with advertisement-specific rules (`.ad-page`, `.ad-wrap`, `.ad-title`, `.ad-subtitle`, `.ad-image-frame`, `.ad-image`, `.ad-cta`) to create the poster look and CTA styling.

### Testing
- Inspected the updated pages with `sed -n '1,120p' index.html` and `sed -n '1,120p' about.html` and verified the new `Ad` nav link is present (success).
- Inspected the new page with `sed -n '1,220p' ad.html` and verified ad markup and local asset reference `assets/tuffin-ad.svg` (success).
- Dumped the appended styles with `tail -n 140 style.css` and verified advertisement CSS rules are present (success).
- Ran `git status --short` to confirm the working tree included the new/modified files (success).
- Attempted to validate the remote image URL with `curl` but the remote request returned `403 Forbidden`, so a local SVG asset was created and used instead (remote check failed but resolved by using `assets/tuffin-ad.svg`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b927f120832097cbe75b9f541c7e)